### PR TITLE
Changed the name in "offliberty"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "offliberty-node",
+  "name": "offliberty",
   "version": "0.0.0",
   "description": "simple interface to the offliberty.com download service.",
   "main": "index.js",


### PR DESCRIPTION
`npm` = node package manager, so `-node` suffix is useless.
Also, `offliberty` package name is free. So, take it. Be fast. :smile: 
